### PR TITLE
Updated README for current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ requests:
 
 ```python
 >>> import requests
->>> import requests_debug
+>>> from requests_debug import debug
 >>> from pprint import pprint
 >>>
->>> requests_debug.install_hook()
+>>> debug.install_hook()
 >>> requests.get("http://httpbin.org/get")
 <Response [200]>
 >>> requests.get("http://httpbin.org/status/418")
 <Response [418]>
 >>>
->>> pprint(requests_debug.items())
+>>> pprint(debug.items())
 [{'method': 'get',
   'status': 200,
   'time': '0.869',
@@ -32,10 +32,10 @@ requests:
   'time': '0.250',
   'time_float': 0.25032901763916016,
   'url': 'http://httpbin.org/status/418'}]
->>> requests_debug.clear_items()
->>> requests_debug.items()
+>>> debug.clear_items()
+>>> debug.items()
 []
->>> requests_debug.uninstall_hook()
+>>> debug.uninstall_hook()
 >>>
 ```
 


### PR DESCRIPTION
Importing `requests_debug` only gives the following objects in the requests_debug namespace:
```python
>>> import requests_debug
>>> dir(requests_debug)
['__builtins__', '__doc__', '__file__', '__name__', '__package__', '__path__', '__version__']
```
and a few more items under python 3.x:
```python
>>> import requests_debug
>>> dir(requests_debug)
['__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__']
```

If all the code from `debug.py` were included in `__init__.py`, then the original README file contents would be correct, but because all the routines have been extracted to the seperate `debug.py` file, then one must specifically import the debug namespace. 

`import requests_debug.debug` would also work, but then instead of `debug.install_hook()` it would be `requests_debug.debug.install_hook()`. Another way around this would be to include `debug.py` from `__init__.py` and alias all the functions. 